### PR TITLE
Update to address #4

### DIFF
--- a/PowerShell Internals/Get-WeekDay.ps1
+++ b/PowerShell Internals/Get-WeekDay.ps1
@@ -24,13 +24,13 @@
 			$Today = (Get-Date).Date
 			if ($Weekday -match 'next') {
 				## The user wants next week's weekday
-				$Range = 0..6
+				$Range = 1..7
 			} elseif ($Weekday -match 'last') {
 				## The user wants last week's weekday
-				$Range = -0.. - 6
+				$Range = -1.. - 7
 			} else {
 				## The user didn't specify so assuming they just want the upcoming weekday
-				$Range = 0..6
+				$Range = 1..7
 			}
 			$Range | foreach {
 				$Day = $Today.AddDays($_);


### PR DESCRIPTION
Changed the ranges from 0-6 to 1-7. To fix the behavior of the script and if asking for `[next|last] weekday` and `weekday` is today, it returns the `[next|last]` weekday instead of today's date.
