### PR TITLE
Remove non-existant 'source' parameter on Write-Verbose in Wait-Ping.ps1

### DIFF
--- a/Networking/Wait-Ping.ps1
+++ b/Networking/Wait-Ping.ps1
@@ -48,7 +48,7 @@
 	)
 	try {
 		$timer = [Diagnostics.Stopwatch]::StartNew();
-		Write-Verbose -Source $MyInvocation.MyCommand -Message "Waiting for [$ComputerName] to become pingable";
+		Write-Verbose -Message "Waiting for [$ComputerName] to become pingable";
 		if ($Offline.IsPresent)
 		{
 			while (Test-Connection -ComputerName $ComputerName -Quiet -Count 1)
@@ -60,7 +60,7 @@
 				}
 				Start-Sleep -Seconds 10;
 			}
-			Write-Verbose -Source $MyInvocation.MyCommand -Message "[$($ComputerName)] is now offline. We waited $([Math]::Round($timer.Elapsed.TotalSeconds, 0)) seconds";
+			Write-Verbose -Message "[$($ComputerName)] is now offline. We waited $([Math]::Round($timer.Elapsed.TotalSeconds, 0)) seconds";
 		}
 		else
 		{
@@ -73,7 +73,7 @@
 				}
 				Start-Sleep -Seconds 10;
 			}
-			Write-Verbose -Source $MyInvocation.MyCommand -Message "Ping is now available on [$($ComputerName)]. We waited $([Math]::Round($timer.Elapsed.TotalSeconds, 0)) seconds";
+			Write-Verbose -Message "Ping is now available on [$($ComputerName)]. We waited $([Math]::Round($timer.Elapsed.TotalSeconds, 0)) seconds";
 		}
 	}
 	catch 


### PR DESCRIPTION
Hi Adam, apologies if you were already working on this, but I was editing it on my local machine and figured I should push it back up as it addresses issue #7.

I've looked through the rest of the repo and made sure that there aren't any other instance of `Write-Verbose -Source ...`.
