### PR TITLE
Fix incorrect data in email report from DNS scavenging script

### DIFF
--- a/DNS/Get-RecordsToBeScavenged.ps1
+++ b/DNS/Get-RecordsToBeScavenged.ps1
@@ -156,7 +156,6 @@ process {
 			}
 		}
 		if ($EmailAddress) {
-			$EmailRecords = @([pscustomobject]@{ 'test'='dfdfdfd'}, [pscustomobject]@{ 'teddddst' = 'dfdfdddddfd' })
 			if ($EmailRecords.Count -eq 0) {
 				Write-Verbose "No stale records found to email"
 			} else {


### PR DESCRIPTION
Changes proposed in this pull request:
 - Remove a spurious value assignment that causes emails to be sent with incorrect data

How to test this code:
 - Verify that the email received from `Get-RecordsToBeScavenged.ps1` contains the expected information

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows Server 2012 R2 and above
