### PR TITLE
`Invoke-Process.ps1`: Return on object instead of Write-Output

### DIFF
--- a/Processes/Invoke-Process.ps1
+++ b/Processes/Invoke-Process.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.5
+.VERSION 2.0
 
 .GUID b787dc5d-8d11-45e9-aeef-5cf3a1f690de
 
@@ -27,54 +27,65 @@
 param()
 
 function Invoke-Process {
-	[CmdletBinding(SupportsShouldProcess)]
-	param
-	(
-		[Parameter(Mandatory)]
-		[ValidateNotNullOrEmpty()]
-		[string]$FilePath,
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+        [string[]]$ArgumentList
+    )
 
-		[Parameter()]
-		[ValidateNotNullOrEmpty()]
-		[string[]]$ArgumentList
-	)
+    $ErrorActionPreference = 'Stop'
 
-	$ErrorActionPreference = 'Stop'
+    try {
+        $stdOutTempFile = "$env:TEMP\$(( New-Guid ).Guid)"
+        $stdErrTempFile = "$env:TEMP\$(( New-Guid ).Guid)"
 
-	try {
-		$stdOutTempFile = "$env:TEMP\$((New-Guid).Guid)"
-		$stdErrTempFile = "$env:TEMP\$((New-Guid).Guid)"
-
-		$startProcessParams = @{
-			FilePath               = $FilePath
-			ArgumentList           = $ArgumentList
-			RedirectStandardError  = $stdErrTempFile
-			RedirectStandardOutput = $stdOutTempFile
-			Wait                   = $true;
-			PassThru               = $true;
-			NoNewWindow            = $true;
-		}
-		if ($PSCmdlet.ShouldProcess("Process [$($FilePath)]", "Run with args: [$($ArgumentList)]")) {
-			$cmd = Start-Process @startProcessParams
-			$cmdOutput = Get-Content -Path $stdOutTempFile -Raw
-			$cmdError = Get-Content -Path $stdErrTempFile -Raw
-			if ($cmd.ExitCode -ne 0) {
-				if ($cmdError) {
-					throw $cmdError.Trim()
-				}
-				if ($cmdOutput) {
-					throw $cmdOutput.Trim()
-				}
-			} else {
-				if ([string]::IsNullOrEmpty($cmdOutput) -eq $false) {
-					Write-Output -InputObject $cmdOutput
-				}
-			}
-		}
-	} catch {
-		$PSCmdlet.ThrowTerminatingError($_)
-	} finally {
-		Remove-Item -Path $stdOutTempFile, $stdErrTempFile -Force -ErrorAction Ignore
-	}
+        $startProcessParams = @{
+            FilePath               = $FilePath
+            RedirectStandardError  = $stdErrTempFile
+            RedirectStandardOutput = $stdOutTempFile
+            Wait                   = $true
+            PassThru               = $true
+            NoNewWindow            = $true
+        }
+        if ($PSCmdlet.ShouldProcess("Process [$($FilePath)]", "Run with args: [$($ArgumentList)]")) {
+            if ($ArgumentList) {
+                Write-Verbose -Message "$FilePath $ArgumentList"
+                $cmd = Start-Process @startProcessParams -ArgumentList $ArgumentList
+            }
+            else {
+                Write-Verbose $FilePath
+                $cmd = Start-Process @startProcessParams
+            }
+            $stdOut = Get-Content -Path $stdOutTempFile -Raw
+            $stdErr = Get-Content -Path $stdErrTempFile -Raw
+            if ([string]::IsNullOrEmpty($stdOut) -eq $false) {
+                $stdOut = $stdOut.Trim()
+            }
+            if ([string]::IsNullOrEmpty($stdErr) -eq $false) {
+                $stdErr = $stdErr.Trim()
+            }
+            $return = [PSCustomObject]@{
+                Name     = $cmd.Name
+                Id       = $cmd.Id
+                ExitCode = $cmd.ExitCode
+                Output   = $stdOut
+                Error    = $stdErr
+            }
+            if ($return.ExitCode -ne 0) {
+                throw $return
+            }
+            else {
+                $return
+            }
+        }
+    }
+    catch {
+        $PSCmdlet.ThrowTerminatingError($_)
+    }
+    finally {
+        Remove-Item -Path $stdOutTempFile, $stdErrTempFile -Force -ErrorAction Ignore
+    }
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Returns an object containing process info instead of a string in `Invoke-Process`.
   - This allows additional handling of the object in a script based on the ExitCode and more control of the output.

How to test this code:
 - Run `Invoke-Process` with and without an error.

Has been tested on (remove any that don't apply):
 - Powershell 5.1 and above
 - Windows 10
