### PR TITLE
Update Remove-AzrVirtualMachine

### DIFF
--- a/Azure/Remove-AzrVirtualMachine.ps1
+++ b/Azure/Remove-AzrVirtualMachine.ps1
@@ -68,8 +68,8 @@ function Remove-AzrVirtualMachine {
 				$vmResource = Get-AzResource @azResourceParams
 				$vmId = $vmResource.Properties.VmId
 				#endregion
-
-				$diagContainerName = ('bootdiagnostics-{0}-{1}' -f $vm.Name.ToLower().Substring(0, $i), $vmId)
+				$vmnameNoSpecialCharacters = $vm.name -replace '[^\p{L}\p{Nd}]', ''
+				$diagContainerName = ('bootdiagnostics-{0}-{1}' -f $vmnameNoSpecialCharacters.ToLower().Substring(0, $i), $vmId)
 				$diagSaRg = (Get-AzStorageAccount | where { $_.StorageAccountName -eq $diagSa }).ResourceGroupName
 				$saParams = @{
 					'ResourceGroupName' = $diagSaRg


### PR DESCRIPTION
Boot Diagnostics Container Name formula now takes into account VM names with special characters like '-' or '_' and removes them before "guessing" the name of the container.
Azure automatically removes these when naming the Boot Diagnostics Container.
