### PR TITLE
Test-PendingReboot.ps1: Allow for truly local box use

### DIFF
--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -1,7 +1,6 @@
-
 <#PSScriptInfo
 
-.VERSION 1.10
+.VERSION 1.11
 
 .GUID fe3d3698-52fc-40e8-a95c-bbc67a507ed1
 
@@ -40,7 +39,7 @@
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
+    # ComputerName is optional. If not specified, localhost is used.
     [ValidateNotNullOrEmpty()]
     [string[]]$ComputerName,
 	
@@ -52,6 +51,10 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $scriptBlock = {
+    if ($null -ne $using) {
+        # $using is only available if this is being called with a remote session
+        $VerbosePreference = $using:VerbosePreference
+    }
 
     function Test-RegistryKey {
         [OutputType('bool')]
@@ -135,8 +138,8 @@ $scriptBlock = {
         {
             # Added test to check first if keys exists, if not each group will return $Null
             # May need to evaluate what it means if one or both of these keys do not exist
-            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' | Where-Object { test-path $_ } | %{ (Get-ItemProperty -Path $_ ).ComputerName } ) -ne 
-            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' | Where-Object { Test-Path $_ } | %{ (Get-ItemProperty -Path $_ ).ComputerName } )
+            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' | Where-Object { test-path $_ } | % { (Get-ItemProperty -Path $_ ).ComputerName } ) -ne 
+            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' | Where-Object { Test-Path $_ } | % { (Get-ItemProperty -Path $_ ).ComputerName } )
         }
         {
             # Added test to check first if key exists
@@ -145,38 +148,61 @@ $scriptBlock = {
         }
     )
 
+    $needsReboot = $false
     foreach ($test in $tests) {
-        Write-Verbose "Running scriptblock: [$($test.ToString())]"
         if (& $test) {
-            $true
-            break
+            $needsReboot = $true
+            #break
+            Write-Verbose "Running scriptblock: [$($test.ToString())] - TRUE"
+        }
+        else {
+            Write-Verbose "Running scriptblock: [$($test.ToString())] - false"            
         }
     }
+
+    if ($needsReboot) {
+        $true
+    }
+}
+
+# if ComputerName was not specified, then use localhost 
+# to ensure that we don't create a Session.
+if ($null -eq $ComputerName) {
+    $ComputerName = "localhost"
 }
 
 foreach ($computer in $ComputerName) {
     try {
-    	$output = @{
-		ComputerName    = $computer
-		IsPendingReboot = $false
-	}
-    	if ($computer -eq 'localhost') {
-		& $scriptBlock
-	} else {
-		$connParams = @{
-		    'ComputerName' = $computer
-		}
-		if ($PSBoundParameters.ContainsKey('Credential')) {
-		    $connParams.Credential = $Credential
-		}
+        $connParams = @{
+            'ComputerName' = $computer
+        }
+        if ($PSBoundParameters.ContainsKey('Credential')) {
+            $connParams.Credential = $Credential
+        }
 
-        	$psRemotingSession = New-PSSession @connParams
-        	$output.IsPendingReboot = Invoke-Command -Session $psRemotingSession -ScriptBlock $scriptBlock
-		[pscustomobject]$output
-	}
-    } catch {
+        $output = @{
+            ComputerName    = $computer
+            IsPendingReboot = $false
+        }
+
+        if ($computer -in ".", "localhost", $env:COMPUTERNAME ) {        
+            if (-not ($output.IsPendingReboot = Invoke-Command -ScriptBlock $scriptBlock)) {
+                $output.IsPendingReboot = $false
+            }
+        }
+        else {
+            $psRemotingSession = New-PSSession @connParams
+        
+            if (-not ($output.IsPendingReboot = Invoke-Command -Session $psRemotingSession -ScriptBlock $scriptBlock)) {
+                $output.IsPendingReboot = $false
+            }
+        }
+        [pscustomobject]$output
+    }
+    catch {
         Write-Error -Message $_.Exception.Message
-    } finally {
+    }
+    finally {
         if (Get-Variable -Name 'psRemotingSession' -ErrorAction Ignore) {
             $psRemotingSession | Remove-PSSession
         }

--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -148,20 +148,11 @@ $scriptBlock = {
         }
     )
 
-    $needsReboot = $false
     foreach ($test in $tests) {
         if (& $test) {
-            $needsReboot = $true
-            #break
-            Write-Verbose "Running scriptblock: [$($test.ToString())] - TRUE"
+            $true
+            break
         }
-        else {
-            Write-Verbose "Running scriptblock: [$($test.ToString())] - false"            
-        }
-    }
-
-    if ($needsReboot) {
-        $true
     }
 }
 

--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -149,6 +149,7 @@ $scriptBlock = {
     )
 
     foreach ($test in $tests) {
+        Write-Verbose "Running scriptblock: [$($test.ToString())]"
         if (& $test) {
             $true
             break
@@ -189,11 +190,9 @@ foreach ($computer in $ComputerName) {
             }
         }
         [pscustomobject]$output
-    }
-    catch {
+    } catch {
         Write-Error -Message $_.Exception.Message
-    }
-    finally {
+    } finally {
         if (Get-Variable -Name 'psRemotingSession' -ErrorAction Ignore) {
             $psRemotingSession | Remove-PSSession
         }


### PR DESCRIPTION
**Enhancement**
I have updated `Test-PendingReboot.ps1` for myself and wanted to share the change. My pull request is based upon **Version 1.11** from https://www.powershellgallery.com/packages/Test-PendingReboot/1.11 and **not** Version 1.10 here in GitHub. 

In my work environment I was unable to start a remote session even to my local box. This update allows the user to address the local box without a remote session.

Changes proposed in this pull request:
 - Allows `$ComputerName` to be optional
 - If `$ComputerName` is null, set it to "localhost" (just for simplicity for later code)
 - If `$ComputerName` is ".", "localhost", or `$env:COMPUTERNAME` then call `Invoke-Command` without a session, otherwise call it as normal.
 - If there is no session, then there is no `$using`. Because of this the script block then must test to see if `$using` is null, and only if it is not null, then pull out the `$using:VerbosePreference`

How to test this code:
 - Run on a local machine using no computer name, ".", and/or "localhost"
 - Run on one machine to another remote computer 

Has been tested on (remove any that don't apply):
 - Powershell 7.1.3
 - Windows 10
