### PR TITLE
Fixed typo in reg key path

### DIFF
--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -132,7 +132,7 @@ $scriptBlock = {
             }
         }
         { Test-RegistryValue -Key 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' -Value 'DVDRebootSignal' }
-        { Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\ServerManager\CurrentRebootAttemps' }
+        { Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\ServerManager\CurrentRebootAttempts' }
         { Test-RegistryValue -Key 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon' -Value 'JoinDomain' }
         { Test-RegistryValue -Key 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon' -Value 'AvoidSpnSet' }
         {


### PR DESCRIPTION
Fixed typo 'CurrentRebootAttempts' in one of the registry key paths to test.

Changes proposed in this pull request:
 - Typo fix 

How to test this code:
- Test not necessary. [Article by Adam here](https://adamtheautomator.com/pending-reboot-registry/) mentions the correct value in the table, as well as multiple commenters who also spotted the typo. 

Has been tested on (remove any that don't apply):
- n/a
![image](https://user-images.githubusercontent.com/13596953/143833749-02afdc2d-0646-46f9-bfd5-05bdd298c152.png)
