### PR TITLE
Update Test-PendingReboot.ps1

### DIFF
--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -127,8 +127,12 @@ $scriptBlock = {
         { Test-RegistryValueNotNull -Key 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Value 'PendingFileRenameOperations2' }
         { 
             # Added test to check first if key exists, using "ErrorAction ignore" will incorrectly return $true
-            'HKLM:\SOFTWARE\Microsoft\Updates' | Where-Object { test-path $_ -PathType Container } | ForEach-Object {            
-                (Get-ItemProperty -Path $_ -Name 'UpdateExeVolatile' -ErrorAction Ignore | Select-Object -ExpandProperty UpdateExeVolatile) -ne 0 
+            'HKLM:\SOFTWARE\Microsoft\Updates' | Where-Object { test-path $_ -PathType Container } | ForEach-Object {
+                if(Test-Path "$_\UpdateExeVolatile" ){ 
+                    (Get-ItemProperty -Path $_ -Name 'UpdateExeVolatile' | Select-Object -ExpandProperty UpdateExeVolatile) -ne 0 
+                }else{ 
+                    $false 
+                }
             }
         }
         { Test-RegistryValue -Key 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' -Value 'DVDRebootSignal' }


### PR DESCRIPTION
Added check if the registry key value UpdateExeVolatile exists

Fixes where the registry value UpdateExeVolative doesn't exist.

Changes proposed in this pull request:
 - Added check for this value before attempting to use it

How to test this code:
 - No change 

Has been tested on (remove any that don't apply):
 - Powershell 5.1

