### PR TITLE
Fix deployment on PS Gallery, default 'localhost' value, -ExpandResultForSingleComputer switch, formatting

### DIFF
--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -8,23 +8,23 @@
 
 .COMPANYNAME Adam the Automator, LLC
 
-.COPYRIGHT 
+.COPYRIGHT
 
 .DESCRIPTION This script tests various registry values to see if the local computer is pending a reboot.
 
-.TAGS 
+.TAGS
 
-.LICENSEURI 
+.LICENSEURI
 
-.PROJECTURI 
+.PROJECTURI
 
-.ICONURI 
+.ICONURI
 
-.EXTERNALMODULEDEPENDENCIES 
+.EXTERNALMODULEDEPENDENCIES
 
-.REQUIREDSCRIPTS 
+.REQUIREDSCRIPTS
 
-.EXTERNALSCRIPTDEPENDENCIES 
+.EXTERNALSCRIPTDEPENDENCIES
 
 .RELEASENOTES
 
@@ -34,7 +34,7 @@
 	Inspiration from: https://gallery.technet.microsoft.com/scriptcenter/Get-PendingReboot-Query-bdb79542
 .EXAMPLE
 	PS> Test-PendingReboot -ComputerName localhost
-	
+
 	This example checks various registry values to see if the local computer is pending a reboot.
 #>
 [CmdletBinding()]
@@ -42,7 +42,7 @@ param(
     # ComputerName is optional. If not specified, localhost is used.
     [ValidateNotNullOrEmpty()]
     [string[]]$ComputerName,
-	
+
     [Parameter()]
     [ValidateNotNullOrEmpty()]
     [pscredential]$Credential
@@ -65,7 +65,7 @@ $scriptBlock = {
             [ValidateNotNullOrEmpty()]
             [string]$Key
         )
-    
+
         $ErrorActionPreference = 'Stop'
 
         if (Get-Item -Path $Key -ErrorAction Ignore) {
@@ -86,7 +86,7 @@ $scriptBlock = {
             [ValidateNotNullOrEmpty()]
             [string]$Value
         )
-    
+
         $ErrorActionPreference = 'Stop'
 
         if (Get-ItemProperty -Path $Key -Name $Value -ErrorAction Ignore) {
@@ -107,7 +107,7 @@ $scriptBlock = {
             [ValidateNotNullOrEmpty()]
             [string]$Value
         )
-    
+
         $ErrorActionPreference = 'Stop'
 
         if (($regVal = Get-ItemProperty -Path $Key -Name $Value -ErrorAction Ignore) -and $regVal.($Value)) {
@@ -125,13 +125,13 @@ $scriptBlock = {
         { Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\PostRebootReporting' }
         { Test-RegistryValueNotNull -Key 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Value 'PendingFileRenameOperations' }
         { Test-RegistryValueNotNull -Key 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Value 'PendingFileRenameOperations2' }
-        { 
+        {
             # Added test to check first if key exists, using "ErrorAction ignore" will incorrectly return $true
-            'HKLM:\SOFTWARE\Microsoft\Updates' | Where-Object { test-path $_ -PathType Container } | ForEach-Object {
-                if(Test-Path "$_\UpdateExeVolatile" ){ 
-                    (Get-ItemProperty -Path $_ -Name 'UpdateExeVolatile' | Select-Object -ExpandProperty UpdateExeVolatile) -ne 0 
-                }else{ 
-                    $false 
+            'HKLM:\SOFTWARE\Microsoft\Updates' | Where-Object { Test-Path $_ -PathType Container } | ForEach-Object {
+                if (Test-Path "$_\UpdateExeVolatile" ) {
+                    (Get-ItemProperty -Path $_ -Name 'UpdateExeVolatile' | Select-Object -ExpandProperty UpdateExeVolatile) -ne 0
+                } else {
+                    $false
                 }
             }
         }
@@ -142,12 +142,12 @@ $scriptBlock = {
         {
             # Added test to check first if keys exists, if not each group will return $Null
             # May need to evaluate what it means if one or both of these keys do not exist
-            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' | Where-Object { test-path $_ } | % { (Get-ItemProperty -Path $_ ).ComputerName } ) -ne 
-            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' | Where-Object { Test-Path $_ } | % { (Get-ItemProperty -Path $_ ).ComputerName } )
+            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' | Where-Object { Test-Path $_ } | ForEach-Object { (Get-ItemProperty -Path $_ ).ComputerName } ) -ne
+            ( 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' | Where-Object { Test-Path $_ } | ForEach-Object { (Get-ItemProperty -Path $_ ).ComputerName } )
         }
         {
             # Added test to check first if key exists
-            'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending' | Where-Object { 
+            'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending' | Where-Object {
                 (Test-Path $_) -and (Get-ChildItem -Path $_) } | ForEach-Object { $true }
         }
     )
@@ -161,10 +161,10 @@ $scriptBlock = {
     }
 }
 
-# if ComputerName was not specified, then use localhost 
+# if ComputerName was not specified, then use localhost
 # to ensure that we don't create a Session.
 if ($null -eq $ComputerName) {
-    $ComputerName = "localhost"
+    $ComputerName = 'localhost'
 }
 
 foreach ($computer in $ComputerName) {
@@ -181,14 +181,13 @@ foreach ($computer in $ComputerName) {
             IsPendingReboot = $false
         }
 
-        if ($computer -in ".", "localhost", $env:COMPUTERNAME ) {        
+        if ($computer -in '.', 'localhost', $env:COMPUTERNAME ) {
             if (-not ($output.IsPendingReboot = Invoke-Command -ScriptBlock $scriptBlock)) {
                 $output.IsPendingReboot = $false
             }
-        }
-        else {
+        } else {
             $psRemotingSession = New-PSSession @connParams
-        
+
             if (-not ($output.IsPendingReboot = Invoke-Command -Session $psRemotingSession -ScriptBlock $scriptBlock)) {
                 $output.IsPendingReboot = $false
             }

--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -39,13 +39,13 @@
 #>
 [CmdletBinding()]
 param(
-    # ComputerName is optional. If not specified, localhost is used.
+    [Parameter(HelpMessage = 'Optional parameter. If omitted, "localhost" (the local machine) is inferred. If not working locally, the target machine must have PS remoting enabled and winrm running.')]
     [ValidateNotNullOrEmpty()]
-    [string[]]$ComputerName,
+    [string[]] $ComputerName = 'localhost',
 
     [Parameter()]
     [ValidateNotNullOrEmpty()]
-    [pscredential]$Credential
+    [pscredential] $Credential
 )
 
 $ErrorActionPreference = 'Stop'
@@ -161,12 +161,6 @@ $scriptBlock = {
     }
 }
 
-# if ComputerName was not specified, then use localhost
-# to ensure that we don't create a Session.
-if ($null -eq $ComputerName) {
-    $ComputerName = 'localhost'
-}
-
 foreach ($computer in $ComputerName) {
     try {
         $connParams = @{
@@ -181,7 +175,7 @@ foreach ($computer in $ComputerName) {
             IsPendingReboot = $false
         }
 
-        if ($computer -in '.', 'localhost', $env:COMPUTERNAME ) {
+        if ($computer -iin @('.', 'localhost', '127.0.0.1', $env:COMPUTERNAME) ) {
             if (-not ($output.IsPendingReboot = Invoke-Command -ScriptBlock $scriptBlock)) {
                 $output.IsPendingReboot = $false
             }

--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.12
+.VERSION 1.13
 
 .GUID fe3d3698-52fc-40e8-a95c-bbc67a507ed1
 
@@ -45,7 +45,9 @@ param(
 
     [Parameter()]
     [ValidateNotNullOrEmpty()]
-    [pscredential] $Credential
+    [pscredential] $Credential,
+
+    [switch] $ExpandResultForSingleComputer
 )
 
 $ErrorActionPreference = 'Stop'
@@ -186,7 +188,11 @@ foreach ($computer in $ComputerName) {
                 $output.IsPendingReboot = $false
             }
         }
-        [pscustomobject]$output
+        if ((1 -eq $ComputerName.Count) -and $ExpandResultForSingleComputer) {
+            $output.IsPendingReboot
+        } else {
+            [pscustomobject]$output
+        }
     } catch {
         Write-Error -Message $_.Exception.Message
     } finally {

--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.11
+.VERSION 1.12
 
 .GUID fe3d3698-52fc-40e8-a95c-bbc67a507ed1
 


### PR DESCRIPTION
Hi
i noticed that the script version published to the PS Gallery is actually **not** correct.
When you `install-` the `script`, a "1.11" version is checked out from the gallery. But that's not the real 1.11 version, it's actually version 1.10, but (for some reason) the script's comment-based help reports version 1.11. This means that all of the localhost logic that avoids opening a PS Session, is missing.

So, in this PR:
- i increased the script version
- i added a default `localhost` value for `$ComputerName` (it was already implemented, but with an `if` statement)
- i added `127.0.0.1` as possible value for the local machine
- i cleaned up the file's formatting (whitespace, braces, ecc) following [Poshcode's "K&R/OTBS" style guide](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81) (used by the official VSCode Powershell extension)

Changes proposed in this pull request:
- i added a `-ExpandResultForSingleComputer` switch parameter that allows for returning just the boolean value, IIF a single computer was specified; for multilple computers, it does nothing

How to test this code:
- `Test-PendingReboot.ps1 127.0.0.1`
- `Test-PendingReboot.ps1 -ExpandResultForSingleComputer` or (short version, as supported by Powershell/.NET) `Test-PendingReboot.ps1' -Expand`

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - win 11 (i didn't alter the system calls so it should still work for any OS)