### PR TITLE
Intune mandatory restart check added

### DIFF
--- a/Random Stuff/Test-PendingReboot.ps1
+++ b/Random Stuff/Test-PendingReboot.ps1
@@ -125,6 +125,7 @@ $scriptBlock = {
         { Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' }
         { Test-RegistryKey -Key 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagesPending' }
         { Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\PostRebootReporting' }
+	{ Test-RegistryKey -Key 'HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\RebootSettings\RebootFlag' }
         { Test-RegistryValueNotNull -Key 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Value 'PendingFileRenameOperations' }
         { Test-RegistryValueNotNull -Key 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Value 'PendingFileRenameOperations2' }
         {


### PR DESCRIPTION
Added HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\RebootSettings\RebootFlag location. If the key is present, it indicates that Intune software post-install mandatory reboot is active.

Fixes # .

Changes proposed in this pull request:
 Add a the HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\RebootSettings\RebootFlag key to $tests

How to test this code:
 - Deploy and install a software with the "Device restart behavior = Intune will force a mandatory device restart" with a grace period set.

Has been tested on (remove any that don't apply):
 - Powershell 5 and above