### PR TITLE
Fixing Invoke-WindowsDiskCleanup.ps1

### DIFF
--- a/File-Folder Management/Invoke-WindowsDiskCleanup.ps1
+++ b/File-Folder Management/Invoke-WindowsDiskCleanup.ps1
@@ -102,7 +102,7 @@ foreach ($keyName in $Section) {
 	$newItemParams = @{
 		Path         = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\$keyName"
 		Name         = 'StateFlags0001'
-		Value        = 1
+		Value        = 2
 		PropertyType = 'DWord'
 		ErrorAction  = 'SilentlyContinue'
 	}


### PR DESCRIPTION
The Invoke-WindowsDiskCleanup.ps1 script was not working properly. As per Microsoft documentation, the "StateFlagsNNNN" needs to equal 2 to be enabled. Before it was set to 1.
See also: https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/automating-disk-cleanup-tool#registry-key-information